### PR TITLE
update virtualbox to 6.0.2

### DIFF
--- a/virtualbox-np.json
+++ b/virtualbox-np.json
@@ -20,7 +20,7 @@
         ]
     },
     "checkver": {
-        "url": "https://update.virtualbox.org/query.php?platform=WINDOWS_64BITS_GENERIC&version=0.0.0",
+        "url": "https://update.virtualbox.org/query.php?platform=WINDOWS_64BITS_GENERIC&version=6.0.0",
         "re": "VirtualBox-(?<version>[\\d.]+)-(?<revision>[\\d]+)-Win.exe"
     },
     "autoupdate": {

--- a/virtualbox-np.json
+++ b/virtualbox-np.json
@@ -2,11 +2,11 @@
     "homepage": "https://www.virtualbox.org/",
     "description": "Powerful x86 and AMD64/Intel64 virtualization product for enterprise as well as home use.",
     "license": "GPL-2.0-only",
-    "version": "6.0.0",
+    "version": "6.0.2",
     "architecture": {
         "64bit": {
-            "url": "https://download.virtualbox.org/virtualbox/6.0.0/VirtualBox-6.0.0-127566-Win.exe#/VBoxSetup.exe",
-            "hash": "e943e84158057da06e3355b0e170b82507cbe7080f5bbf06c9f4a7674ffa783c"
+            "url": "https://download.virtualbox.org/virtualbox/6.0.2/VirtualBox-6.0.2-128162-Win.exe#/VBoxSetup.exe",
+            "hash": "42e9d4a3120585a3578072ecbf77dc707119ac19f4588e3fa327acfd52b21c87"
         }
     },
     "installer": {


### PR DESCRIPTION
there is an additional commit to fix the autoupdate, since the request "https://update.virtualbox.org/query.php?platform=WINDOWS_64BITS_GENERIC&version=0.0.0" still reports 5.2.24-128163 as the latest version.