### PR TITLE
Fix WinFSP manifest, add SSHFS-Win

### DIFF
--- a/sshfs-np.json
+++ b/sshfs-np.json
@@ -1,0 +1,33 @@
+{
+    "homepage": "http://www.github.com/billziss-gh/sshfs-win/",
+    "description": "SSHFS For Windows",
+    "version": "2.7.17334",
+    "license": "GPL-2.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/billziss-gh/sshfs-win/releases/download/v2.7.17334/sshfs-win-2.7.17334-x64.msi",
+            "hash": "sha1:8b8c5bb43e0e7dad7334b4ad9f40742e17611050"
+        },
+        "32bit": {
+            "url": "https://github.com/billziss-gh/sshfs-win/releases/download/v2.7.17334/sshfs-win-2.7.17334-x32.msi",
+            "hash": "sha1:0dfdf4f14d3555a0d5b90b84db586cce2bf6fa43"
+        }
+    },
+    "depends": {
+        "winfsp-np": "winfsp-np"
+    },
+    "checkver": {
+        "url": "https://github.com/billziss-gh/sshfs-win/releases/latest",
+        "re": "v(?<version>[\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/billziss-gh/sshfs-win/releases/download/v$matchVersion/sshfs-win-$matchVersion-x64.msi"
+            },
+            "32bit": {
+                "url": "https://github.com/billziss-gh/sshfs-win/releases/download/v$matchVersion/sshfs-win-$matchVersion-x86.msi"
+            }
+        }
+    }
+}

--- a/winfsp-np.json
+++ b/winfsp-np.json
@@ -3,27 +3,13 @@
     "description": "WinFsp attempts to ease the task of writing a new file system for Windows in the same way that FUSE has done so for UNIX.",
     "version": "1.4.19049",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/billziss-gh/winfsp/releases/download/v1.4.19049/winfsp-1.4.19049.msi#/winfsp.msi",
-    "hash": "3c6df9f7bb505d6796e886efcfc19dcf25d76053832f139bc2f2627be0fa8324",
-    "installer": {
-        "file": "winfsp.msi",
-        "keep": "true"
-    },
-    "uninstaller": {
-        "file": "winfsp.msi"
-    },
+    "url": "https://github.com/billziss-gh/winfsp/releases/download/v1.4/winfsp-1.4.19016.msi",
+    "hash": "sha1:7213869e25b0a8335f0bf661a0e9ed24115cca11",
     "checkver": {
         "url": "https://github.com/billziss-gh/winfsp/releases/latest",
-        "re": "v(?<version>[\\d.]+)/winfsp-(?<short>[\\d.]+).*\\.msi"
+        "re": "v(?<short>[\\d.]+)/winfsp-(?<version>[\\d.]+).*\\.msi"
     },
     "autoupdate": {
-        "url": "https://github.com/billziss-gh/winfsp/releases/download/v$matchVersion/winfsp-$matchShort.msi#/winfsp.msi",
-        "installer": {
-            "file": "winfsp.msi",
-            "keep": "true"
-        },
-        "uninstaller": {
-            "file": "winfsp.msi"
-        }
+        "url": "https://github.com/billziss-gh/winfsp/releases/download/v$matchShort/winfsp-$matchVersion.msi"
     }
 }


### PR DESCRIPTION
Previous WinFSP manifest was fetching the wrong resource from GitHub artifacts. Also removed installer/uninstaller declarations since scoop [discovers MSI installers by default](https://github.com/lukesampson/scoop/wiki/App-Manifests#Optional%20Properties).

[SSHFS-Win](https://www.github.com/billziss-gh/sshfs-win) is another utility by [Bill Zissimopoulos](https://www.github.com/billziss-gh) that depends on WinFSP.