### PR TITLE
Add VMware Horizon Client manifest

### DIFF
--- a/vmware-horizon-client-np.json
+++ b/vmware-horizon-client-np.json
@@ -1,11 +1,11 @@
 {
-    "version": "4.10.0-11021086",
+    "version": "5.0.0-12606690",
     "description": "VMware Horizon Client for Windows allows you to connect to your VMware Horizon virtual desktop.",
     "homepage": "https://www.vmware.com/products/horizon.html",
     "architecture": {
         "64bit": {
-            "url": "https://download3.vmware.com/software/view/viewclients/CART19FQ4/VMware-Horizon-Client-4.10.0-11021086.exe",
-            "hash": "a2bec40b8cc20b945f2abeac69ec6797cefd075addcf6b87f916b58830f5bb7f",
+            "url": "https://download3.vmware.com/software/view/viewclients/CART20FQ1/VMware-Horizon-Client-5.0.0-12606690.exe",
+            "hash": "92f447bfef2efc193e682c4d95bbd1cf137be5d040b7ba7f4e752107e94b9fd6",
             "installer": {
                 "script": [
                     "Start-Process cmd -Verb RunAs \"/c $dir\\VMware-Horizon-Client-$version.exe /install /norestart /silent INSTALLDIR=\"\"$dir\\files\"\" AUTO_UPDATE_ENABLED=0\" -Wait -WindowStyle Hidden"

--- a/vmware-horizon-client-np.json
+++ b/vmware-horizon-client-np.json
@@ -1,0 +1,27 @@
+{
+    "version": "4.10.0-11021086",
+    "description": "VMware Horizon Client for Windows allows you to connect to your VMware Horizon virtual desktop.",
+    "homepage": "https://www.vmware.com/products/horizon.html",
+    "architecture": {
+        "64bit": {
+            "url": "https://download3.vmware.com/software/view/viewclients/CART19FQ4/VMware-Horizon-Client-4.10.0-11021086.exe",
+            "hash": "a2bec40b8cc20b945f2abeac69ec6797cefd075addcf6b87f916b58830f5bb7f",
+            "installer": {
+                "script": [
+                    "Start-Process cmd -Verb RunAs \"/c $dir\\VMware-Horizon-Client-$version.exe /install /norestart /silent INSTALLDIR=\"\"$dir\\files\"\" AUTO_UPDATE_ENABLED=0\" -Wait -WindowStyle Hidden"
+                ]
+            },
+            "uninstaller": {
+                "script": [
+                    "Start-Process cmd -Verb RunAs \"/c $dir\\VMware-Horizon-Client-$version.exe /uninstall /norestart /silent\" -Wait -WindowStyle Hidden"
+                ]
+            },
+            "shortcuts": [
+                [
+                    "files\\vmware-view.exe",
+                    "VMware Horizon Client"
+                ]
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Add manifest for VMware Horizon Client 5.0.0. Some notes:

- Installer/uninstaller requires elevation, wasn't able to get it working without UAC prompt.
- Installer sets permissions on the directory passed with `INSTALLDIR`, which caused problems when scoop tried to create `install.json` and `manifest.json` files in non-elevated shell. Specified install directory as `$dir\files` to workaround the problem. 
- Wasn't able to figure out a working `checkver`/`autoupdate` strategy based on the ever-changing `downloadGroup` in VMware download page (ex. compare URLs for [4.10.0] and [5.0.0])

Please take a look, any comments or suggestions welcome!

[4.10.0]: https://my.vmware.com/web/vmware/details?productId=578&rPId=29501&downloadGroup=CART19FQ4_WIN_410
[5.0.0]: https://my.vmware.com/web/vmware/details?downloadGroup=CART20FQ1_WIN_500&productId=863&rPId=31231
