### PR TITLE
Fix incomplete cleanup/uninstall of VMware Horizon Client

### DIFF
--- a/vmware-horizon-client-np.json
+++ b/vmware-horizon-client-np.json
@@ -4,16 +4,21 @@
     "homepage": "https://www.vmware.com/products/horizon.html",
     "architecture": {
         "64bit": {
-            "url": "https://download3.vmware.com/software/view/viewclients/CART20FQ1/VMware-Horizon-Client-5.0.0-12606690.exe",
+            "url": "https://download3.vmware.com/software/view/viewclients/CART20FQ1/VMware-Horizon-Client-5.0.0-12606690.exe#/VMware-Horizon-Client-Setup.exe",
             "hash": "92f447bfef2efc193e682c4d95bbd1cf137be5d040b7ba7f4e752107e94b9fd6",
             "installer": {
                 "script": [
-                    "Start-Process cmd -Verb RunAs \"/c $dir\\VMware-Horizon-Client-$version.exe /install /norestart /silent INSTALLDIR=\"\"$dir\\files\"\" AUTO_UPDATE_ENABLED=0\" -Wait -WindowStyle Hidden"
+                    "# Installer script run in elevated 'cmd' shell, and sets filesystem permissions on",
+                    "# INSTALLDIR for administrators. When scoop tries to create 'manifest.json' file in a",
+                    "# non-elevated shell, this causes an error. Set INSTALLDIR to a subdirectory of scoop",
+                    "# $dir, so filesystem permissions on the current directory aren't changed.",
+                    "Start-Process cmd -Verb RunAs \"/c $dir\\VMware-Horizon-Client-Setup.exe /install /norestart /silent INSTALLDIR=\"\"$dir\\files\"\" AUTO_UPDATE_ENABLED=0\" -Wait -WindowStyle Hidden"
                 ]
             },
             "uninstaller": {
                 "script": [
-                    "Start-Process cmd -Verb RunAs \"/c $dir\\VMware-Horizon-Client-$version.exe /uninstall /norestart /silent\" -Wait -WindowStyle Hidden"
+                    "# Ensure the INSTALLDIR subdirectory is removed in the elevated shell after successful uninstall.",
+                    "Start-Process cmd -Verb RunAs \"/c $dir\\VMware-Horizon-Client-Setup.exe /uninstall /norestart /silent && rmdir \"\"$dir\\files\"\"\" -Wait -WindowStyle Hidden"
                 ]
             },
             "shortcuts": [


### PR DESCRIPTION
# Error
<pre><code>PS> scoop cleanup vmware-horizon-client-np
Removing vmware-horizon-client-np: 5.0.0-12606690
Remove-Item : Access to the path 'C:\Users\name\scoop\apps\vmware-horizon-client-np\5.0.0-12606690\files' is denied.
At C:\Users\name\scoop\apps\scoop\current\libexec\scoop-cleanup.ps1:51 char:9
+         Remove-Item $dir -ErrorAction Stop -Recurse -Force
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : PermissionDenied: (C:\Users\name\sc\u2026.0.0-12606690\files:DirectoryInfo) [Remove-Item], UnauthorizedAccessException
+ FullyQualifiedErrorId : RemoveFileSystemItemUnAuthorizedAccess,Microsoft.PowerShell.Commands.RemoveItemCommand
</code></pre>

# Fix
During install, a subdirectory of scoop application version `$dir` is defined to workaround an issue with `manifest.json` creation in non-elevated shell. Uninstall script should remove this subdirectory to ensure scoop cleanup/uninstall can complete successfully.