### PR TITLE
sshfs-np, winfsp-np: Install MSI packages (instead of extracting them)

### DIFF
--- a/sshfs-np.json
+++ b/sshfs-np.json
@@ -1,20 +1,33 @@
 {
+    "##": "Renaming .msi to .msi_ so that it will not be automatically extracted by Scoop.",
     "homepage": "http://www.github.com/billziss-gh/sshfs-win/",
     "description": "SSHFS For Windows",
     "version": "2.7.17334",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/billziss-gh/sshfs-win/releases/download/v2.7.17334/sshfs-win-2.7.17334-x64.msi",
+            "url": "https://github.com/billziss-gh/sshfs-win/releases/download/v2.7.17334/sshfs-win-2.7.17334-x64.msi#/setup.msi_",
             "hash": "246b7caa8c9b66c44aff7629da0a6767d405a5d78b7b81f429a5141c124da1e1"
         },
         "32bit": {
-            "url": "https://github.com/billziss-gh/sshfs-win/releases/download/v2.7.17334/sshfs-win-2.7.17334-x86.msi",
+            "url": "https://github.com/billziss-gh/sshfs-win/releases/download/v2.7.17334/sshfs-win-2.7.17334-x86.msi#/setup.msi_",
             "hash": "77a201b1623a34aff40f7c26d916ca761bda23c7e54557e6769bd9f9c0062d25"
         }
     },
     "depends": {
         "winfsp-np": "winfsp-np"
+    },
+    "pre_install": [
+        "if (-not (is_admin)) {",
+        "    Write-Host 'Elevated prompt is needed for correct installation.' -f Yellow",
+        "    exit(1)",
+        "}"
+    ],
+    "installer": {
+        "script": "Invoke-ExternalCommand msiexec -ArgumentList @('/i', \"$dir\\setup.msi_\", '/qn') | Out-Null"
+    },
+    "uninstaller": {
+        "script": "Invoke-ExternalCommand msiexec -ArgumentList @('/x', \"$dir\\setup.msi_\", '/qn') | Out-Null"
     },
     "checkver": {
         "url": "https://github.com/billziss-gh/sshfs-win/releases/latest",
@@ -23,10 +36,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/billziss-gh/sshfs-win/releases/download/v$matchShort/sshfs-win-$matchVersion-x64.msi"
+                "url": "https://github.com/billziss-gh/sshfs-win/releases/download/v$matchShort/sshfs-win-$matchVersion-x64.msi#/setup.msi_"
             },
             "32bit": {
-                "url": "https://github.com/billziss-gh/sshfs-win/releases/download/v$matchShort/sshfs-win-$matchVersion-x86.msi"
+                "url": "https://github.com/billziss-gh/sshfs-win/releases/download/v$matchShort/sshfs-win-$matchVersion-x86.msi#/setup.msi_"
             }
         }
     }

--- a/winfsp-np.json
+++ b/winfsp-np.json
@@ -1,15 +1,27 @@
 {
+    "##": "Renaming .msi to .msi_ so that it will not be automatically extracted by Scoop.",
     "homepage": "http://www.secfs.net/winfsp/",
     "description": "WinFsp attempts to ease the task of writing a new file system for Windows in the same way that FUSE has done so for UNIX.",
     "version": "1.4.19049",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/billziss-gh/winfsp/releases/download/v1.4.19049/winfsp-1.4.19049.msi",
+    "url": "https://github.com/billziss-gh/winfsp/releases/download/v1.4.19049/winfsp-1.4.19049.msi#/setup.msi_",
     "hash": "3c6df9f7bb505d6796e886efcfc19dcf25d76053832f139bc2f2627be0fa8324",
+    "pre_install": [
+        "if (-not (is_admin)) {",
+        "    Write-Host 'Elevated prompt is needed for correct installation.' -f Yellow",
+        "    exit(1)",
+        "}"
+    ],
+    "installer": {
+        "script": "Invoke-ExternalCommand msiexec -ArgumentList @('/i', \"$dir\\setup.msi_\", '/qn') | Out-Null"
+    },
+    "uninstaller": {
+        "script": "Invoke-ExternalCommand msiexec -ArgumentList @('/x', \"$dir\\setup.msi_\", '/qn') | Out-Null"
+    },
     "checkver": {
-        "url": "https://github.com/billziss-gh/winfsp/releases/latest",
-        "re": "v(?<short>[\\d.]+)/winfsp-(?<version>[\\d.]+).*\\.msi"
+        "github": "https://github.com/billziss-gh/winfsp"
     },
     "autoupdate": {
-        "url": "https://github.com/billziss-gh/winfsp/releases/download/v$matchShort/winfsp-$matchVersion.msi"
+        "url": "https://github.com/billziss-gh/winfsp/releases/download/v$version/winfsp-$version.msi#/setup.msi_"
     }
 }


### PR DESCRIPTION
close #41 

Notes:
* I tried using `sudo` and `Invoke-ExternalCommand -RunAs` for installer script, so that an **UAC prompt** will pop up when user is not running the terminal under Admin. Unfortunately none of them worked for `msiexec`.

* I am not familiar with how `sshfs` works. Is it better to add some items into `bin` or `shortcuts`?