### PR TITLE
Add SQL Server Management Studio manifest

### DIFF
--- a/sql-server-management-studio-np.json
+++ b/sql-server-management-studio-np.json
@@ -1,0 +1,36 @@
+{
+    "homepage": "https://docs.microsoft.com/en-us/sql/ssms/download-sql-server-management-studio-ssms",
+    "description": "An integrated environment for SQL Server infrastructure administration and T-SQL development.",
+    "version": "15.0.18131.0",
+    "url": "https://go.microsoft.com/fwlink/?linkid=2094583#/SSMS-Setup-ENU.exe",
+    "hash": "b5c3669a7970074eb8292316406242d69b3d151c8bdd9a3d92a67b7a712a73e8",
+    "installer": {
+        "script": [
+            "$log = \"$dir\\SSMS-Setup-ENU-Install.log\"",
+            "$bin = \"$dir\\SSMS-Setup-ENU.exe\"",
+            "$args = \"/c $bin /install /quiet /norestart /log $log SSMSInstallRoot=$dir\"",
+            "# 3010 exit code means successful, but reboot pending",
+            "$success = @(0, 3010)",
+            "$rc = (Start-Process cmd -Verb Runas \"$args\" -Wait -WindowStyle hidden -PassThru).ExitCode",
+            "if ($rc -notin $success) { abort \"Install failed, see log for details:`n$log\" }"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "$log = \"$dir\\SSMS-Setup-ENU-Uninstall.log\"",
+            "$bin = \"$dir\\SSMS-Setup-ENU.exe\"",
+            "$args = \"/c $bin /uninstall /quiet /norestart /log $log\"",
+            "$success = @(0, 3010)",
+            "$rc = (Start-Process cmd -Verb Runas \"$args\" -Wait -WindowStyle hidden -PassThru).ExitCode",
+            "if ($rc -notin $success) { abort \"Uninstall failed, see log for details:`n$log\" }"
+        ]
+    },
+    "shortcuts": [
+        [
+            "Common7\\IDE\\Ssms.exe",
+            "Microsoft SQL Server Management Studio 18.1"
+        ]
+    ]
+}
+
+

--- a/sql-server-management-studio-np.json
+++ b/sql-server-management-studio-np.json
@@ -1,9 +1,9 @@
 {
     "homepage": "https://docs.microsoft.com/en-us/sql/ssms/download-sql-server-management-studio-ssms",
     "description": "An integrated environment for SQL Server infrastructure administration and T-SQL development.",
-    "version": "15.0.18131.0",
-    "url": "https://go.microsoft.com/fwlink/?linkid=2094583#/SSMS-Setup-ENU.exe",
-    "hash": "b5c3669a7970074eb8292316406242d69b3d151c8bdd9a3d92a67b7a712a73e8",
+    "version": "15.0.18142.0",
+    "url": "https://go.microsoft.com/fwlink/?linkid=2099720#/SSMS-Setup-ENU.exe",
+    "hash": "8416c6d6c2b39dfe4bccca88cf90db9f4cfab28a3d6c1d1b35594e62a02d8181",
     "installer": {
         "script": [
             "$log = \"$dir\\SSMS-Setup-ENU-Install.log\"",
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "Common7\\IDE\\Ssms.exe",
-            "Microsoft SQL Server Management Studio 18.1"
+            "Microsoft SQL Server Management Studio 18.2"
         ]
     ]
 }


### PR DESCRIPTION
Add manifest for [SQL Server Management Studio](https://docs.microsoft.com/en-us/sql/ssms/download-sql-server-management-studio-ssms). Some notes:

- Installer/uninstaller requires elevation, wasn't able to get it working without UAC prompt.
- If install/uninstall fails, call scoop `abort` with message pointing to log file for details
- `checkver` should be working, haven't been able to figure out `autoupdate` based on the difference between release label (e.g. 18.2) and version number

Please take a look, any comments or suggestions welcome. Thanks!