### PR TITLE
teamviewer-np: Add version 14.4.2669

### DIFF
--- a/teamviewer-np.json
+++ b/teamviewer-np.json
@@ -1,0 +1,31 @@
+{
+    "homepage": "https://www.teamviewer.com",
+    "license": {
+        "identifier":"Shareware",
+        "url": "https://www.teamviewer.com/en/eula/"
+    },
+    "description": "Software for remote control, desktop sharing, online meetings, web conferencing and file transfer between computers.",
+    "version": "14.4.2669",
+    "url": "https://dl.teamviewer.com/download/TeamViewer_Setup.exe#/setup.exe",
+    "hash": "df26627cc29716b65a3ed72f78d59808244f9bc4ad2624657ddbee79d2baa422",
+    "installer": {
+        "script": [
+            "Invoke-ExternalCommand \"$dir\\setup.exe\" -ArgumentList @('/S', '/D=$dir', '/norestart') -RunAs | Out-Null",
+            "Remove-Item \"$dir\\setup.exe\""
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "taskkill /F /IM teamviewer.exe /FI 'status eq running'",
+            "$pg_x86 = (Get-Item Env:programfiles`(x86`)).Value",
+            "Invoke-ExternalCommand \"$pg_x86\\TeamViewer\\uninstall.exe\" -ArgumentList @('/S', '/norestart') -RunAs | Out-Null"
+        ]
+    },
+    "checkver": {
+        "url": "https://www.teamviewer.com/en/download/windows/",
+        "re": ">\\s*([\\d.]+)\\s*<"
+    },
+    "autoupdate": {
+        "url": "https://dl.teamviewer.com/download/TeamViewer_Setup.exe#/setup.exe"
+    }
+}


### PR DESCRIPTION
This adds non-portable version of **TeamViewer**.

Some of **TeamViewer**'s function (such as "keep logged in" or "Grand Easy Access") only works when the user installs TeamViewer with the installer.

(see: https://github.com/lukesampson/scoop-extras/issues/2604)

Please let me know if there are any problems. Thanks.