### PR TITLE
Include `bin` and `shortcuts` to VirtualBox manifests.

### DIFF
--- a/virtualbox-np.json
+++ b/virtualbox-np.json
@@ -19,6 +19,30 @@
             "Start-Process cmd -Verb Runas \"/c msiexec /x $id /qn\" -Wait -WindowStyle hidden"
         ]
     },
+    "bin": [
+        "VBoxBalloonCtrl.exe",
+        "VBoxBugReport.exe",
+        "VBoxDTrace.exe",
+        "VBoxExtPackHelperApp.exe",
+        "VBoxHeadless.exe",
+        "vbox-img.exe",
+        "VBoxManage.exe",
+        "VBoxNetDHCP.exe",
+        "VBoxNetNAT.exe",
+        "VBoxSDL.exe",
+        "VBoxSDS.exe",
+        "VBoxSVC.exe",
+        "VBoxTestOGL.exe",
+        "VBoxWebSrv.exe",
+        "VirtualBox.exe",
+        "VirtualBoxVM.exe"
+    ],
+    "shortcuts": [
+        [
+            "VirtualBox.exe",
+            "VirtualBox"
+        ]
+    ],
     "checkver": {
         "url": "https://update.virtualbox.org/query.php?platform=WINDOWS_64BITS_GENERIC&version=6.0.0",
         "re": "VirtualBox-(?<version>[\\d.]+)-(?<revision>[\\d]+)-Win.exe"

--- a/virtualbox52-np.json
+++ b/virtualbox52-np.json
@@ -15,6 +15,28 @@
             "Start-Process cmd -Verb Runas \"/c msiexec /x $id /qn\" -Wait -WindowStyle hidden"
         ]
     },
+    "bin": [
+        "VBoxBalloonCtrl.exe",
+        "VBoxBugReport.exe",
+        "VBoxDTrace.exe",
+        "VBoxExtPackHelperApp.exe",
+        "VBoxHeadless.exe",
+        "vbox-img.exe",
+        "VBoxManage.exe",
+        "VBoxNetDHCP.exe",
+        "VBoxNetNAT.exe",
+        "VBoxSDL.exe",
+        "VBoxSVC.exe",
+        "VBoxTestOGL.exe",
+        "VBoxWebSrv.exe",
+        "VirtualBox.exe"
+    ],
+    "shortcuts": [
+        [
+            "VirtualBox.exe",
+            "VirtualBox"
+        ]
+    ],
     "checkver": "VirtualBox-(?<version>[\\d.]+)-(?<revision>\\d+)-Win.exe",
     "autoupdate": {
         "url": "http://download.virtualbox.org/virtualbox/$version/VirtualBox-$version-$matchRevision-Win.exe#/VBox52Setup.exe",


### PR DESCRIPTION
Since I'm using a lot of the commandline tools for configurations via scripts, it's really helpful to call the executable by their name directly.

By the way, would you prefer that we make the `virtualbox52-np` and `virtualbox-np` able to coexists?
If so, I can update the PR by doing something like this on `virtualbox52-np.json`:
```
...
"bin": [
    [
        "VBoxBalloonCtrl.exe",
        "VBoxBalloonCtrl52"
    ],
    [
        "VBoxBugReport.exe",
        "VBoxBugReport52"
    ],
    ...
],
...
```

Thanks!