### PR TITLE
Move installer to architecture

### DIFF
--- a/logitech-gaming-software-np.json
+++ b/logitech-gaming-software-np.json
@@ -9,15 +9,18 @@
     "architecture": {
         "64bit": {
             "url": "https://download01.logi.com/web/ftp/pub/techsupport/gaming/LGS_9.02.65_x64_Logitech.exe",
-            "hash": "e037727f2e571f41864d93fbcc094e124eda3e1dcd2d56973f1f65c5a577bf55"
+            "hash": "e037727f2e571f41864d93fbcc094e124eda3e1dcd2d56973f1f65c5a577bf55",
+            "installer": {
+                "script": "Start-Process -Wait \"$dir\\LGS_$($version)_x64_Logitech.exe\" /S -Verb RunAs"
+            }
         },
         "32bit": {
             "url": "https://download01.logi.com/web/ftp/pub/techsupport/gaming/LGS_9.02.65_x86_Logitech.exe",
-            "hash": "fd70176ddeeee0a24bbaceef67a67004debf53ed437db7d7c06786f8d4fd8eeb"
+            "hash": "fd70176ddeeee0a24bbaceef67a67004debf53ed437db7d7c06786f8d4fd8eeb",
+            "installer": {
+                "script": "Start-Process -Wait \"$dir\\LGS_$($version)_x86_Logitech.exe\" /S -Verb RunAs"
+            }
         }
-    },
-    "installer": {
-        "script": "Start-Process -Wait \"$dir\\LGS_$($version)_x$(if ($architecture -eq '64bit') { '64' } else { '86' })_Logitech.exe\" /S -Verb RunAs"
     },
     "uninstaller": {
         "script": [


### PR DESCRIPTION
Sorry I didn't catch this before you merged it, but the convention seems to be to wrap `installer.script` in `architecture` rather than using an if-else like I did.