### PR TITLE
Notepad++: some minor fixes

### DIFF
--- a/notepadplusplus-np.json
+++ b/notepadplusplus-np.json
@@ -1,38 +1,37 @@
 {
     "homepage": "https://notepad-plus-plus.org/",
-    "version": "7.8",
+    "version": "7.8.1",
     "license": "GPL",
-    "notes": "The following page explains how to add explorer context menu entries for notepad++. http://docs.notepad-plus-plus.org/index.php/Explorer_Context_Menu",
     "architecture": {
         "64bit": {
-            "url": "http://download.notepad-plus-plus.org/repository/7.x/7.8/npp.7.8.Installer.x64.exe",
-            "hash": "ddaf2a899b3cfc81b814ed24bab4c42386853444c2c50d7bb676127b04ffea9a"
+            "url": "http://download.notepad-plus-plus.org/repository/7.x/7.8.1/npp.7.8.1.Installer.x64.exe#/installer.exe",
+            "hash": "51ea006fac7c7cf88dda19133fd2e701d53a774d0f9a6f094178db40424e2bd1"
         },
         "32bit": {
-            "url": "http://download.notepad-plus-plus.org/repository/7.x/7.8/npp.7.8.Installer.exe",
-            "hash": "f2bb733a6afcff34e8e72cbeb3a200dd223e732e2e1275322532635cdf066027"
+            "url": "http://download.notepad-plus-plus.org/repository/7.x/7.8.1/npp.7.8.1.Installer.exe#/installer.exe",
+            "hash": "d99718a113e86bd874ad4aac3557a7190e8008352eb758716ed568ae3bf6b0e9"
         }
     },
     "checkver": "<strong>Current Version (.*?)</strong>",
     "bin": "notepad++.exe",
     "installer": {
-        "args": [
-            "/S",
-            "/allowAppDataPluginsLoading",
-            "/D=$dir"
-        ]
+        "script": "Invoke-ExternalCommand \"$dir\\installer.exe\" -ArgumentList @('/S', \"/D=$dir\") -RunAs | Out-Null"
     },
     "uninstaller": {
-        "file": "uninstall.exe",
-        "args": "/S"
+        "script": [
+            "Invoke-ExternalCommand \"$dir\\uninstall.exe\" -ArgumentList @('/S') -RunAs | Out-Null",
+            "Start-Process taskkill -ArgumentList @('/F', '/IM', 'explorer.exe') -Wait",
+            "explorer",
+            "Start-Sleep -Seconds 2"
+        ]
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://download.notepad-plus-plus.org/repository/$majorVersion.x/$version/npp.$version.Installer.x64.exe"
+                "url": "http://download.notepad-plus-plus.org/repository/$majorVersion.x/$version/npp.$version.Installer.x64.exe#/installer.exe"
             },
             "32bit": {
-                "url": "http://download.notepad-plus-plus.org/repository/$majorVersion.x/$version/npp.$version.Installer.exe"
+                "url": "http://download.notepad-plus-plus.org/repository/$majorVersion.x/$version/npp.$version.Installer.exe#/installer.exe"
             }
         },
         "hash": {


### PR DESCRIPTION
close #69

* Update the package (version 7.8 -> 7.8.1)
* Use `Invoke-ExternalCommand` instead of running the installer directly. When the user installs the package without admin rights, the program will show a **UAC popup** to acquire admin rights. (instead of showing error messages and abort installation, like the case described in #69)
* Remove the argument `allowAppDataPluginsLoading` of the installer since [it is no longer in use](https://github.com/notepad-plus-plus/notepad-plus-plus/commit/113212547fcf89ac302ec35839bac109995ee1fa)
* Remove **notes**. (Context menu is already added in the **nonportable** version. No need to show the message.)
* Restart `explorer.exe` after running the uninstaller. This will avoid the **file in use** error during uninstall. (The file is actually unlocked after `explorer.exe` completely reloaded, therefore I added `Start-Sleep` to wait for the loading)

Please let me know if there are any problems. Thanks.
